### PR TITLE
update java version detector and maven rigging to support java 9

### DIFF
--- a/derrick/detectors/image/java.py
+++ b/derrick/detectors/image/java.py
@@ -33,6 +33,11 @@ class JavaVersionDetector(Detector):
         if matches:
             version_arr = matches.group(1).split(".")
             if len(version_arr) > 1:
-                detect_version = version_arr[1]
+                # Java 7,8 version string is the format of "1.8.0_131"
+                # Java 9 version string is like this: "9.0.1"
+                if version_arr[0] == '1':
+                    detect_version = version_arr[1]
+                else:
+                    detect_version = version_arr[0]
 
         return detect_version

--- a/derrick/rigging/maven_rigging/templates/Dockerfile.j2
+++ b/derrick/rigging/maven_rigging/templates/Dockerfile.j2
@@ -1,10 +1,10 @@
-FROM maven:3-jdk-{{ version }} AS build-env
+FROM maven:3-jdk-{{ version }}-slim AS build-env
 
 WORKDIR /app
 COPY . /app
 RUN mvn package
 
-FROM openjdk:{{ version }}-jre-alpine
+FROM openjdk:{{ version }}-jre-slim
 COPY --from=build-env /app/target/*.jar /app.jar
 
 ENV JAVA_OPTS=""


### PR DESCRIPTION
This PR tried to fixed two issues:

1. Java 9 version string in format of '9.0.1' instead of '1.9.0', so original java version detector will return wrong major version number, which is '0'

2. maven rigging template will generate maven:3-jdk-9 and openjdk:9-jre-alpine for Java 9

maven:3-jdk-9 has an SSL issue: https://github.com/docker-library/openjdk/issues/145
openjdk:9-jre-alpine is not a valid base image (no tag existed for 9-jre-alpine)

Solution is to replace two images as maven:3-jdk-{{version}}-slim and openjdk:{{version}}-jre-slim

Generated Dockerfile are tested again java 7,8,9

The Dockerfile will not work properly for java 6, as maven:3-jdk-6 does not exist.