### PR TITLE
use standard jre base image instead of *-slim base image

### DIFF
--- a/derrick/detectors/image/java.py
+++ b/derrick/detectors/image/java.py
@@ -20,7 +20,7 @@ class JavaVersionDetector(Detector):
         version = default_version;
         try:
             output = subprocess.check_output(["java", "-version"], shell=False, stderr=subprocess.STDOUT)
-            version = JavaVersionDetector.get_most_relative_version(output)
+            version = JavaVersionDetector.get_most_relative_version(output.decode('utf-8'))
         except Exception as e:
             Logger.debug("Failed to detect Java version,because of %s" % e)
             Logger.debug("Use default Java version:%s instead ." % default_version)

--- a/derrick/rigging/maven_rigging/templates/Dockerfile.j2
+++ b/derrick/rigging/maven_rigging/templates/Dockerfile.j2
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . /app
 RUN mvn package
 
-FROM openjdk:{{ version }}-jre-slim
+FROM openjdk:{{ version }}-jre
 COPY --from=build-env /app/target/*.jar /app.jar
 
 ENV JAVA_OPTS=""


### PR DESCRIPTION
*-slim base image does not have curl which will cause health check always fail